### PR TITLE
allow admin role to post reports

### DIFF
--- a/validate_doc_update.js
+++ b/validate_doc_update.js
@@ -1,5 +1,5 @@
 function(newDoc, oldDoc, userCtx) {
-	if(userCtx.roles.indexOf("_admin") < 0 && userCtx.roles.indexOf("reporter") < 0) {
+	if(userCtx.roles.indexOf("_admin") < 0 && userCtx.roles.indexOf("reporter") < 0 && userCtx.roles.indexOf("_writer") < 0) {
 		throw({"forbidden": "You may only post reports with reporter role "});
 	}
 }

--- a/validate_doc_update.js
+++ b/validate_doc_update.js
@@ -1,5 +1,5 @@
 function(newDoc, oldDoc, userCtx) {
-	if(userCtx.roles.indexOf("reporter") < 0) {
+	if(userCtx.roles.indexOf("_admin") < 0 && userCtx.roles.indexOf("reporter") < 0) {
 		throw({"forbidden": "You may only post reports with reporter role "});
 	}
 }


### PR DESCRIPTION
I was trying to migrate data from my "production" install to my dev server.
I used the couchdb-dump/load tool (http://code.google.com/p/couchdb-python/) and realized I couldn't use my admin user.

Added _admin to the list of users who can upload data.
