### PR TITLE
Switch to "new RegExp" style regular expression

### DIFF
--- a/updates/report.js
+++ b/updates/report.js
@@ -93,7 +93,7 @@ var addReportSignature = function(report) {
             }
             result.full = exceptionName + " " + trim(faultyLine);
 
-            var captureRegEx = /\((.*)\)/g;
+            var captureRegEx = new RegExp("\((.*)\)", "g");
             var capturedFaultyLine = captureRegEx.exec(faultyLine);
             var faultyLineDigest = "unknown";
             if(capturedFaultyLine) {


### PR DESCRIPTION
On older versions of SpiderMonkey (I think our server was running 1.8.0) calling exec() on a RegExp object created like this 

```
var repexp=/exp/;
```

throws an error.  If instead your create your object like this

```
var repexp=new RegExp("exp");
```

exec() works fine.
