### PR TITLE
Escape backslashes in js string so they are part of RegEx

### DIFF
--- a/updates/report.js
+++ b/updates/report.js
@@ -93,7 +93,7 @@ var addReportSignature = function(report) {
             }
             result.full = exceptionName + " " + trim(faultyLine);
 
-            var captureRegEx = new RegExp("\((.*)\)", "g");
+            var captureRegEx = new RegExp("\\((.*)\\)", "g");
             var capturedFaultyLine = captureRegEx.exec(faultyLine);
             var faultyLineDigest = "unknown";
             if(capturedFaultyLine) {


### PR DESCRIPTION
The change from // style regex to new RegExp missed a subtle change. Because new RegExp takes a javascript string as a parameter, the backslashes need to be escaped so that they survive in to the string, and then serve to escape the outer "()"s there. You can see the problem with the current version in littleguy77's test data:
https://paulscode.iriscouch.com/acralyzer-custom/_design/acralyzer/index.html#/reports-browser/mupen64plusae

The signature.digest and signature.full fields are nearly identical. But, I think the intention was to capture only the filename for signature.digest.
