### PR TITLE
Add Atom 1.0 feed

### DIFF
--- a/lists/atom.js
+++ b/lists/atom.js
@@ -1,0 +1,77 @@
+function (head, req) {
+    var fixDate = function(s) {
+        if (Date.parse) {
+            try {
+                var d = new Date(Date.parse(s));
+                return d.toISOString();
+            } catch (e) {
+            }
+        }
+        return s;
+    };
+
+    var escape = function(s){
+        if (!s) { s = ""; }
+        return String(s).replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    };
+
+    var appDBPrefix = 'acra-';
+
+    start({ "headers" : {"Content-type" : "application/atom+xml"}});
+    var NB_ITEMS_MAX = 30;
+
+    send('<?xml version="1.0" encoding="utf-8"?>');
+
+    send('<feed xmlns="http://www.w3.org/2005/Atom">');
+    send('<author><name>acra-storage</name><uri>https://github.com/ACRA/acra-storage</uri></author>');
+
+    var appName = req.path[0].substring(appDBPrefix.length);
+    send('<title>' + appName + ' latest Crash Reports</title>');
+    send('<subtitle>Acralyzer latest crash reports.</subtitle>');
+
+    var atomUrl = '/' + appName + '/_design/acra-storage/_list/atom/recent-items?descending=true';
+
+    send('<link href="' + atomUrl + '" rel="self" />');
+    send('<link href="/acralyzer/_design/acralyzer/index.html#/dashboard/' + appName + '" />');
+    send('<id>https://' + req.headers.Host + atomUrl + '</id>');
+
+    var nbItems = 0;
+    while ((nbItems < NB_ITEMS_MAX) && (row = getRow())) {
+        if (nbItems == 0) {
+            send('<updated>' + fixDate(row.key) + '</updated>');
+        }
+        nbItems++;
+
+        send('<entry>');
+        send('<title>');
+        if(row.value.signature) {
+            send(escape(row.value.signature.digest));
+        }
+        send('</title>');
+        send('<link href="');
+        send('/acralyzer/_design/acralyzer/index.html#/report-details/' + appName + '/' + row.id +'" />');
+        send('<id>urn:uuid:' + row.id + '</id>');
+        send('<updated>' + fixDate(row.key) + '</updated>');
+
+        send('<content type="xhtml"><div xmlns="http://www.w3.org/1999/xhtml">');
+        if(row.value.application_version_name) {
+            send('<p>app_version: ' + escape(row.value.application_version_name) + '</p>');
+        }
+        if(row.value.android_version) {
+            send('<p>android_version: ' + escape(row.value.android_version) + '</p>');
+        }
+        if(row.value.device) {
+            send('<p>device: ' + escape(row.value.device) + '</p>');
+        }
+        if(row.value.signature) {
+            send('<p>crash line: ' + escape(row.value.signature.full) + '</p>');
+        }
+        send('</div></content>');
+        send('</entry>');
+    }
+    send('</feed>');
+}


### PR DESCRIPTION
The current rss.js code always embeds non-SSL (http:) links in the feed data.  This is not a good thing because in typical acralyzer installations, access to the bug reports requires transmitting the CouchDB administrator login/password over the wire.  Also, crash reports may contain sensitive user data.

I experimented with adding SSL autodetection to rss.js, but encountered the following limitations:
- The Netscape RSS 0.91 spec [discourages](http://scripting.com/netscapeDocs/RSS%200_91%20Spec,%20revision%203.html#link) (if not disallows) protocols other than http: and ftp:.
- RSS does not support relative URLs at all.
- CouchDB does not seem to give us an indication of whether SSL was used to access the current document, so we would have to "guess" (or maybe put it in a configuration file somewhere).

All three problems can be addressed by using Atom instead, and specifying relative URLs in the feed.  So I am submitting atom.js, accessed via `https://HOST/acra-PROJECT/_design/acra-storage/_list/atom/recent-items?descending=true`.  i.e. just replace "rss" with "atom" in the URL.

The output from this code passes the w3c.org feed validator.  There is one non-fatal warning regarding the use of relative URLs in the "self" link, which is allowed but discouraged.

atom.js incorporates @halkeye's pending fixes from bug #10.

[See here](http://mail-archives.apache.org/mod_mbox/couchdb-user/201408.mbox/%3CCAJiQ%3D7D857CSDD9OhN_%3DU0hYT8pogaEM%2BDj3xriqQdpv0CcNnQ%40mail.gmail.com%3E) for background discussion on the CouchDB list; there are additional posts in the thread.
